### PR TITLE
Fix module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gotify/plugin-template
+module github.com/lekoOwO/gotify2telegram
 
 go 1.18
 


### PR DESCRIPTION
The Gotify server cannot load two plugins built with the same module name, so make it unique.